### PR TITLE
fix: correct env var, fix brandstr check and guard against window in server context

### DIFF
--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -18,9 +18,9 @@ const parseBrand = (str = '') => {
  * @returns {import("./global.js").Brand} brand object
  */
 export const getBrand = (brandStr = '') => {
-    if (brandStr === '') return parseBrand(brandStr);
-    if (window?.location?.host) return parseBrand(window.location.host);
-    if (process?.env?.BRAND) return parseBrand(process.env.BRAND);
+    if (brandStr !== '') return parseBrand(brandStr);
+    if (!isServer && window?.location?.host) return parseBrand(window.location.host);
+    if (process?.env?.NMP_BRAND) return parseBrand(process.env.NMP_BRAND);
     return parseBrand();
 };
 


### PR DESCRIPTION
This PR fixes 3 issues:

1. brandStr was being checked for equality when it should have been for inequality
2. reference window in a server context was throwing an error
3. the env var should have been NMP_BRAND not BRAND

The net result was that point 1. was always true and so always returned Finn as the brand context. This prevented the other 2 errors from showing up.