### PR TITLE
fix: update eik urls

### DIFF
--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -56,7 +56,7 @@ export const getGlobalStyles = async (brand) => {
     const { sld, tld } = brand;
     const urls = [
         `https://assets.finn.no/pkg/@warp-ds/fonts/v1/${sld}-${tld}.min.css`,
-        `https://assets.finn.no/pkg/@warp-ds/tokens/v1/${sld}-${tld}.css`,
+        `https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/${sld}-${tld}.css`,
         `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.min.css`,
     ];
     return await loadStyles(urls);

--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -55,9 +55,9 @@ const loadStyles = async (urls = []) => {
 export const getGlobalStyles = async (brand) => {
     const { sld, tld } = brand;
     const urls = [
-        `https://assets.finn.no/pkg/@warp-ds/fonts/v1/${sld}-${tld}.min.css`,
+        `https://assets.finn.no/pkg/@warp-ds/fonts/v1/${sld}-${tld}.css`,
         `https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/${sld}-${tld}.css`,
-        `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.min.css`,
+        `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css`,
     ];
     return await loadStyles(urls);
 };


### PR DESCRIPTION
Updates done to the fonts and css repo have made it possible to import brand CSS from https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/finn-no.css, as well as fetching minified CSS files without the need to include `.min.` in the file name.