### PR TITLE
fix: make sure that process not called in the window context

### DIFF
--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -19,8 +19,8 @@ const parseBrand = (str = '') => {
  */
 export const getBrand = (brandStr = '') => {
     if (brandStr !== '') return parseBrand(brandStr);
-    if (!isServer && window?.location?.host) return parseBrand(window.location.host);
-    if (process?.env?.NMP_BRAND) return parseBrand(process.env.NMP_BRAND);
+    if (!isServer() && window?.location?.host) return parseBrand(window.location.host);
+    if (isServer() && process?.env?.NMP_BRAND) return parseBrand(process.env.NMP_BRAND);
     return parseBrand();
 };
 


### PR DESCRIPTION
- Call isServer for window and server processes
- Add additional checks, to make sure that `process` is not called in window context, to avoid `ReferenceError: process is not defined` in the browsers