### PR TITLE
fix: add polyfill for cssstylesheet objects in older browsers

### DIFF
--- a/warp-element/.gitignore
+++ b/warp-element/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/warp-element/.npmrc
+++ b/warp-element/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/warp-element/package.json
+++ b/warp-element/package.json
@@ -21,7 +21,6 @@
   "license": "MIT",
   "dependencies": {
     "@podium/element": "1.0.8",
-    "construct-style-sheets-polyfill": "3.1.0",
     "lit": "2.7.6"
   },
   "devDependencies": {

--- a/warp-element/package.json
+++ b/warp-element/package.json
@@ -6,19 +6,16 @@
   "main": "./src/element.js",
 	"files": [
 		"./src",
-		"./dist",
 		"README.md"
 	],
   "exports": {
-    ".": "./dist/element.js",
-    "./element.js": "./dist/element.js",
-    "./global.js": "./dist/global.js",
-    "./utils.js": "./dist/utils.js"
+    ".": "./src/element.js",
+    "./element.js": "./src/element.js",
+    "./global.js": "./src/global.js",
+    "./utils.js": "./src/utils.js"
   },
   "scripts": {
-    "jsdoc": "tsc",
-    "build": "rollup -c",
-    "prepublish": "npm run build"
+    "jsdoc": "tsc"
   },
   "author": "",
   "license": "MIT",
@@ -28,11 +25,7 @@
     "lit": "2.7.6"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^25.0.4",
-    "@rollup/plugin-node-resolve": "^15.2.1",
-    "@rollup/plugin-terser": "^0.4.3",
     "@types/node": "^20.4.7",
-    "rollup": "^3.28.1",
     "typescript": "^5.1.6"
   }
 }

--- a/warp-element/package.json
+++ b/warp-element/package.json
@@ -4,23 +4,35 @@
   "version": "0.0.1-alpha.4",
   "description": "",
   "main": "./src/element.js",
+	"files": [
+		"./src",
+		"./dist",
+		"README.md"
+	],
   "exports": {
-    ".": "./src/element.js",
-    "./element.js": "./src/element.js",
-    "./global.js": "./src/global.js",
-    "./utils.js": "./src/utils.js"
+    ".": "./dist/element.js",
+    "./element.js": "./dist/element.js",
+    "./global.js": "./dist/global.js",
+    "./utils.js": "./dist/utils.js"
   },
   "scripts": {
-    "jsdoc": "tsc"
+    "jsdoc": "tsc",
+    "build": "rollup -c",
+    "prepublish": "npm run build"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
     "@podium/element": "1.0.8",
+    "construct-style-sheets-polyfill": "3.1.0",
     "lit": "2.7.6"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.4",
+    "@rollup/plugin-node-resolve": "^15.2.1",
+    "@rollup/plugin-terser": "^0.4.3",
     "@types/node": "^20.4.7",
+    "rollup": "^3.28.1",
     "typescript": "^5.1.6"
   }
 }

--- a/warp-element/src/element.js
+++ b/warp-element/src/element.js
@@ -1,12 +1,10 @@
-import { PodiumElement } from '@podium/element';
-import { styles } from './global.js';
+import { PodiumElement } from "@podium/element";
+import { styles } from "./global.js";
 
-export default class WarpElement extends PodiumElement {    
-    static styles = [
-        ...styles,
-    ];
+export default class WarpElement extends PodiumElement {
+  static styles = [...styles];
 
-    constructor() {
-        super();
-    }
+  constructor() {
+    super();
+  }
 }

--- a/warp-element/src/global.js
+++ b/warp-element/src/global.js
@@ -1,4 +1,4 @@
-import { getBrand, getGlobalStyles } from './utils.js';
+import { getBrand, getGlobalStyles } from "./utils.js";
 
 /**
  * Returns a Brand object with top level- and

--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -43,7 +43,10 @@ const loadStyles = async (urls = []) => {
     "replace" in CSSStyleSheet.prototype;
 
   if (!supportsAdoptingStyleSheets) {
-    await import("https://assets.finn.no/npm/construct-style-sheets-polyfill/3.1.0/polyfill.js");
+    await import(
+      // @ts-ignore
+      "https://assets.finn.no/npm/construct-style-sheets-polyfill/3.1.0/polyfill.js"
+    );
   }
 
   const requests = await Promise.all(

--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -37,7 +37,14 @@ const loadStyles = async (urls = []) => {
     });
   }
 
-  await import("construct-style-sheets-polyfill");
+  // only load polyfill if needed, and only client side.
+  const supportsAdoptingStyleSheets =
+    "adoptedStyleSheets" in Document.prototype &&
+    "replace" in CSSStyleSheet.prototype;
+
+  if (!supportsAdoptingStyleSheets) {
+    await import("construct-style-sheets-polyfill");
+  }
 
   const requests = await Promise.all(
     urls.map((url) => {

--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -43,7 +43,7 @@ const loadStyles = async (urls = []) => {
     "replace" in CSSStyleSheet.prototype;
 
   if (!supportsAdoptingStyleSheets) {
-    await import("construct-style-sheets-polyfill");
+    await import("https://assets.finn.no/npm/construct-style-sheets-polyfill/3.1.0/polyfill.js");
   }
 
   const requests = await Promise.all(

--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -1,51 +1,61 @@
-import { unsafeCSS } from 'lit';
+import { unsafeCSS } from "lit";
 
 const isServer = () => {
-    return !(typeof window !== 'undefined');
+  return !(typeof window !== "undefined");
 };
 
-const parseBrand = (str = '') => {
-    if (str.toLocaleLowerCase().includes('blocket')) return { sld: 'blocket', tld: 'se' };
-    if (str.toLocaleLowerCase().includes('tori')) return { sld: 'tori', tld: 'fi' };
-    if (str.toLocaleLowerCase().includes('finn')) return { sld: 'finn', tld: 'no' };
-    if (str.toLocaleLowerCase().includes('dba')) return { sld: 'dba', tld: 'dk' };
-    return { sld: 'finn', tld: 'no' };
+const parseBrand = (str = "") => {
+  if (str.toLocaleLowerCase().includes("blocket"))
+    return { sld: "blocket", tld: "se" };
+  if (str.toLocaleLowerCase().includes("tori"))
+    return { sld: "tori", tld: "fi" };
+  if (str.toLocaleLowerCase().includes("finn"))
+    return { sld: "finn", tld: "no" };
+  if (str.toLocaleLowerCase().includes("dba")) return { sld: "dba", tld: "dk" };
+  return { sld: "finn", tld: "no" };
 };
-
 
 /*
  * @param {string} [brandStr] - a string with brand information
  * @returns {import("./global.js").Brand} brand object
  */
-export const getBrand = (brandStr = '') => {
-    if (brandStr !== '') return parseBrand(brandStr);
-    if (!isServer() && window?.location?.host) return parseBrand(window.location.host);
-    if (isServer() && process?.env?.NMP_BRAND) return parseBrand(process.env.NMP_BRAND);
-    return parseBrand();
+export const getBrand = (brandStr = "") => {
+  if (brandStr !== "") return parseBrand(brandStr);
+  if (!isServer() && window?.location?.host)
+    return parseBrand(window.location.host);
+  if (isServer() && process?.env?.NMP_BRAND)
+    return parseBrand(process.env.NMP_BRAND);
+  return parseBrand();
 };
 
 const loadStyles = async (urls = []) => {
-    const server = isServer();
+  const server = isServer();
 
-    if (server) {
-        return urls.map((style) => {
-            return unsafeCSS(`@import url('${style}');`);
-        });
-    }
-
-    const requests = await Promise.all(urls.map((url) => {
-        return fetch(url);
-    }));
-
-    const sheets = await Promise.all(requests.map((response) => {
-        return response.text();
-    }));
-
-    return sheets.map((style) => {
-        const sheet = new CSSStyleSheet();
-        sheet.replaceSync(style);
-        return sheet;
+  if (server) {
+    return urls.map((style) => {
+      return unsafeCSS(`@import url('${style}');`);
     });
+  }
+
+  await import("construct-style-sheets-polyfill");
+
+  const requests = await Promise.all(
+    urls.map((url) => {
+      return fetch(url);
+    })
+  );
+
+  const sheets = await Promise.all(
+    requests.map((response) => {
+      return response.text();
+    })
+  );
+
+  return sheets.map((style) => {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(style);
+    return sheet;
+  });
 };
 /**
  *
@@ -53,11 +63,11 @@ const loadStyles = async (urls = []) => {
  * @returns {Promise<import("./global.js").Styles>} CSS style information
  */
 export const getGlobalStyles = async (brand) => {
-    const { sld, tld } = brand;
-    const urls = [
-        `https://assets.finn.no/pkg/@warp-ds/fonts/v1/${sld}-${tld}.css`,
-        `https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/${sld}-${tld}.css`,
-        `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css`,
-    ];
-    return await loadStyles(urls);
+  const { sld, tld } = brand;
+  const urls = [
+    `https://assets.finn.no/pkg/@warp-ds/fonts/v1/${sld}-${tld}.css`,
+    `https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/${sld}-${tld}.css`,
+    `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css`,
+  ];
+  return await loadStyles(urls);
 };


### PR DESCRIPTION
## Background

Older versions of Safari don't support using CSSStyleSheet objects as constructors and not nearly enough users have upgraded to the newer versions.

## What This Does

Adds a polyfill that patches in CSSStyleSheet object functionality into older browsers.