### PR TITLE
fix: always export styles and fetch replaceSync on TLA fallback

### DIFF
--- a/warp-element/src/element.js
+++ b/warp-element/src/element.js
@@ -2,7 +2,7 @@ import { PodiumElement } from "@podium/element";
 import { styles } from "./global.js";
 
 export default class WarpElement extends PodiumElement {
-  static styles = [...styles];
+  static styles = [styles];
 
   constructor() {
     super();


### PR DESCRIPTION
Adds a not so nice fallback for browsers that don't support top level await (TLA).
The server side works as before with global.js returning a Lit CSSResult object, on the client side, a single CSSStyleSheet object is now always returned synchronously so that an async fallback could be added that just replaces the contents of the CSSStylesheet object with a new set of styles once fetched.