### PR TITLE
fix: support older browsers by always polyfilling

### DIFF
--- a/warp-element/package.json
+++ b/warp-element/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@podium/element": "1.0.8",
+    "construct-style-sheets-polyfill": "3.1.0",
     "lit": "2.7.6"
   },
   "devDependencies": {

--- a/warp-element/src/global.js
+++ b/warp-element/src/global.js
@@ -1,5 +1,6 @@
 import { CSSResult, unsafeCSS } from "lit";
 import { getBrand, getGlobalStyles, isServer } from "./utils.js";
+import "construct-style-sheets-polyfill";
 
 /**
  * Returns a Brand object with top level- and

--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -43,18 +43,6 @@ const loadStyles = async (urls = []) => {
     return loadResult;
   }
 
-  // only load polyfill if needed, and only client side.
-  const supportsAdoptingStyleSheets =
-    "adoptedStyleSheets" in Document.prototype &&
-    "replace" in CSSStyleSheet.prototype;
-
-  if (!supportsAdoptingStyleSheets) {
-    await import(
-      // @ts-ignore
-      "https://assets.finn.no/npm/construct-style-sheets-polyfill/3.1.0/polyfill.js"
-    );
-  }
-
   const requests = await Promise.all(
     urls.map((url) => {
       return fetch(url);


### PR DESCRIPTION
## Background

There is a chicken and egg problem where older browsers do not support CSSStyleSheet OR top level await and we've been using TLA to load the CSSStyleSheet polyfill via dynamic imports from Eik.

## The issue

Since we can't use top level await in older browsers AND since we must (synchronously) export the css style sheet object for use in Lit elements, we can't dynamically import the polyfill from an external source using TLA. 

## The solution

The simplest solution is to just inline the polyfill and eat the 2kb Gzipped that this costs us. The polyfill includes code to not apply itself if in a Node.js context OR in a context that already supports CSSStyleSheets so the only cost here is the extra kbs which I think we just have to live with.