### PR TITLE
feat: add components css file to global files

### DIFF
--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -72,6 +72,7 @@ export const getGlobalStyles = async (brand) => {
     `https://assets.finn.no/pkg/@warp-ds/fonts/v1/${sld}-${tld}.css`,
     `https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/${sld}-${tld}.css`,
     `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css`,
+    `https://assets.finn.no/pkg/@warp-ds/css/v1/components.css`,
   ];
   return await loadStyles(urls);
 };


### PR DESCRIPTION
After discussion with @AnnaRybkina and looking into the compressed file size of components.css (7kb) I feel good about adding this to the core package for the following reasons:

1. Everyone's purge builds will be smaller and allow us to optimise this chunk of CSS across layouts and podlets
2. It will be super easy to make the SSR friendly Warp custom elements (just add the @warp-ds/elements-core package and use it as a base class and you should be gtg
3. It should simplify Warp setups (Anna was looking into getting the safelist classes to always be exclude classes) as users wont need to configure safelist/exclude classes themselves.

I don't know precisely how big the average purge build is likely to be for any given component but I suspect with this change it might be something like:

* Warp React and Vue components: =0kb
* Warp custom elements components: ~0kb
* Layouts and podlets: ~2kb

With this in mind, looking at an example of how pages are loaded:

**Cold load of the frontpage:**
Core CSS files (4 files): ~15kb
Frontpage layout CSS: ~2kb
header: ~2kb
recommendations: ~2kb
globalSearch: ~2kb
banner: ~2kb
footer: ~2kb
broadcast: ~2kb
gdprPopup: ~2kb
onboarding: ~2kb
tjtFeed: ~2kb
loginRefresh: ~2kb
**Total CSS: 37kb (15 CSS requests)**

**User clicks through to the general marketplace frontpage**
Core CSS (4 files): 0, loaded from cache
Market Frontpage layout CSS: ~2kb
header: 0, loaded from cache
recommendations: 0, loaded from cache
globalSearch: 0, loaded from cache
banner: 0, loaded from cache
footer: 0, loaded from cache
broadcast: 0, loaded from cache
employerProfileRecommendations: ~2kb
userAccounts: ~2kb
lastSearch: ~2kb
bapSearchLinks: ~2kb
jobSearchLinks: ~2kb
realestateSearchLinks: ~2kb
b2bSearchLinks: ~2kb
boatSearchLinks: ~2kb
mcSearchLinks: ~2kb
carSearchLinks: ~2kb
marketCMSArticles: ~2kb
**Total CSS: ~24kb (12 CSS requests)**

The sheer number of podlets being loaded in some pages means that we really want to get the total CSS size down as low as possible per podlet and pulling components.css into the global core is a very large saving down the line.

N.B. 
* All values are brotli compressed numbers
* These are extreme examples given. Most pages don't load **17 podlets** as the recommerce mfp does. Having said that, these are high traffic pages.
* Refreshes of these pages will of course load no CSS from the network as **all** CSS will come from cache.