### PR TITLE
fix: adding work around for Safari top level await bug

### DIFF
--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -31,6 +31,44 @@ class StyleLoadResult {
   css = "";
 }
 
+const loadStylesSync = (urls = []) => {
+  const loadResult = new StyleLoadResult();
+  const server = isServer();
+
+  if (server) {
+    for (const url of urls) {
+      loadResult.css += `@import url('${url}');`;
+    }
+    loadResult.isServer = true;
+    return loadResult;
+  }
+
+  for (const url of urls) {
+    const xhr = new XMLHttpRequest()
+    xhr.open("GET", url, false);
+    xhr.send();
+    loadResult.css += xhr.responseText;
+  }
+
+  return loadResult;
+};
+/**
+ *
+ * @param {import("./global.js").Brand} brand - target brand
+ * @returns {StyleLoadResult} CSS stylesheets as strings
+ */
+export const getGlobalStylesSync = (brand) => {
+  const { sld, tld } = brand;
+  const urls = [
+    `https://assets.finn.no/pkg/@warp-ds/fonts/v1/${sld}-${tld}.css`,
+    `https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/${sld}-${tld}.css`,
+    `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css`,
+    `https://assets.finn.no/pkg/@warp-ds/css/v1/components.css`,
+  ];
+  return loadStylesSync(urls);
+};
+
+
 const loadStyles = async (urls = []) => {
   const loadResult = new StyleLoadResult();
   const server = isServer();
@@ -44,15 +82,15 @@ const loadStyles = async (urls = []) => {
   }
 
   const requests = await Promise.all(
-    urls.map((url) => {
-      return fetch(url);
-    })
+      urls.map((url) => {
+        return fetch(url);
+      })
   );
 
   const cssResult = await Promise.all(
-    requests.map((response) => {
-      return response.text();
-    })
+      requests.map((response) => {
+        return response.text();
+      })
   );
 
   for (const sheet of cssResult) {


### PR DESCRIPTION
As discussed here in [#tmp-tori-search-page-js-bug](https://sch-chat.slack.com/archives/C06ERNG223T), one way to get the search pages to work is to circumvent the [Safari bug with multiple top level await](https://bugs.webkit.org/show_bug.cgi?id=242740).

The down side to adding this is that we get a Flash Of Unstyled Content (FOUC), the positive is that the page will work.