### PR TITLE
fix: target es2017, but allow top-level await

### DIFF
--- a/warp-element/esbuild.js
+++ b/warp-element/esbuild.js
@@ -10,9 +10,12 @@ eik.load().then(() => {
       outfile: "./dist/element.js",
       sourcemap: true,
       minify: true,
-      target: ["es2022"],
-			legalComments: `none`,
-			plugins: [eik.plugin()],
+      supported: {
+        "top-level-await": true, // We're handling the fallback
+      },
+      target: ["es2017"],
+      legalComments: `none`,
+      plugins: [eik.plugin()],
     }),
     build({
       entryPoints: ["./src/global.js"],
@@ -21,9 +24,12 @@ eik.load().then(() => {
       outfile: "./dist/global.js",
       sourcemap: true,
       minify: true,
-      target: ["es2022"],
-			legalComments: `none`,
-			plugins: [eik.plugin()],
+      supported: {
+        "top-level-await": true, // We're handling the fallback
+      },
+      target: ["es2017"],
+      legalComments: `none`,
+      plugins: [eik.plugin()],
     }),
   ]);
 });

--- a/warp-element/src/global.js
+++ b/warp-element/src/global.js
@@ -1,5 +1,10 @@
 import { CSSResult, unsafeCSS } from "lit";
-import {getBrand, getGlobalStyles, getGlobalStylesSync, isServer} from "./utils.js";
+import {
+  getBrand,
+  getGlobalStyles,
+  getGlobalStylesSync,
+  isServer,
+} from "./utils.js";
 import "construct-style-sheets-polyfill";
 
 /**
@@ -33,14 +38,19 @@ if (isServer()) {
   try {
     const UA = window.navigator.userAgent;
     // @ts-ignore
-    const isWebkit = /WebKit/.test(UA) && !/Chrome/.test(UA) && !/Edg/.test(UA) && !window.MSStream;
+    const isWebkit =
+      /WebKit/.test(UA) &&
+      !/Chrome/.test(UA) &&
+      !/Edg/.test(UA) &&
+      !window.MSStream;
     if (isWebkit) {
       // We do this because Safari does not always throw when this happens.
       // As is mentioned in this bug https://bugs.webkit.org/show_bug.cgi?id=242740, which leads to
       // Safari in certain cases stopping JS execution.
-      throw new Error("DoesNotSupportTopLevelAwait")
+      throw new Error("DoesNotSupportTopLevelAwait");
     }
-    // block on fetching styles. This will throw in older browsers that don't support top level await
+    // Block on fetching styles. This will throw in older browsers that don't support top level await.
+    // They will fall back to a sync XMLHttpRequest.
     const sheets = await getGlobalStyles(brand);
     styles.replaceSync(sheets.css);
   } catch (err) {


### PR DESCRIPTION
We handle the case where the browser throws with a sync XMLHttpRequest.

Target the same as other Warp libraries while we figure out how to best distribute the browserslist.

https://esbuild.github.io/api/#supported