### PR TITLE
feat: remove tokens and fonts from warp element

### DIFF
--- a/warp-element/src/global.js
+++ b/warp-element/src/global.js
@@ -1,24 +1,10 @@
 import { CSSResult, unsafeCSS } from "lit";
 import {
-  getBrand,
   getGlobalStyles,
   getGlobalStylesSync,
   isServer,
 } from "./utils.js";
 import "construct-style-sheets-polyfill";
-
-/**
- * Returns a Brand object with top level- and
- * second level domain string.
- *
- *  @see https://developer.mozilla.org/en-US/docs/Glossary/Second-level_Domain
- *  @see https://developer.mozilla.org/en-US/docs/Glossary/TLD
- * @typedef {Object} Brand
- * @property {string} sld - second level domain
- * @property {string} tld - top level domain
- */
-
-const brand = getBrand();
 
 /**
  * Styles object compatible with LitElement.
@@ -31,7 +17,7 @@ const brand = getBrand();
 let styles;
 
 if (isServer()) {
-  const sheets = await getGlobalStyles(brand);
+  const sheets = await getGlobalStyles();
   styles = unsafeCSS(sheets.css);
 } else {
   styles = new CSSStyleSheet();
@@ -52,11 +38,11 @@ if (isServer()) {
     }
     // Block on fetching styles. This will throw in older browsers that don't support top level await.
     // They will fall back to a sync XMLHttpRequest.
-    const sheets = await getGlobalStyles(brand);
+    const sheets = await getGlobalStyles();
     styles.replaceSync(sheets.css);
   } catch (err) {
     // we do a synchronous call for browsers which don't suppoert top-level await
-    const sheets = getGlobalStylesSync(brand);
+    const sheets = getGlobalStylesSync();
     styles.replaceSync(sheets.css);
   }
 }

--- a/warp-element/src/utils.js
+++ b/warp-element/src/utils.js
@@ -2,30 +2,6 @@ export const isServer = () => {
   return !(typeof window !== "undefined");
 };
 
-const parseBrand = (str = "") => {
-  if (str.toLocaleLowerCase().includes("blocket"))
-    return { sld: "blocket", tld: "se" };
-  if (str.toLocaleLowerCase().includes("tori"))
-    return { sld: "tori", tld: "fi" };
-  if (str.toLocaleLowerCase().includes("finn"))
-    return { sld: "finn", tld: "no" };
-  if (str.toLocaleLowerCase().includes("dba")) return { sld: "dba", tld: "dk" };
-  return { sld: "finn", tld: "no" };
-};
-
-/**
- * @param {string} [brandStr] - a string with brand information
- * @returns {import("./global.js").Brand} brand object
- */
-export const getBrand = (brandStr = "") => {
-  if (brandStr !== "") return parseBrand(brandStr);
-  if (!isServer() && window?.location?.host)
-    return parseBrand(window.location.host);
-  if (isServer() && process?.env?.NMP_BRAND)
-    return parseBrand(process.env.NMP_BRAND);
-  return parseBrand();
-};
-
 class StyleLoadResult {
   isServer = false;
   css = "";
@@ -54,14 +30,10 @@ const loadStylesSync = (urls = []) => {
 };
 /**
  *
- * @param {import("./global.js").Brand} brand - target brand
  * @returns {StyleLoadResult} CSS stylesheets as strings
  */
-export const getGlobalStylesSync = (brand) => {
-  const { sld, tld } = brand;
+export const getGlobalStylesSync = () => {
   const urls = [
-    `https://assets.finn.no/pkg/@warp-ds/fonts/v1/${sld}-${tld}.css`,
-    `https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/${sld}-${tld}.css`,
     `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css`,
     `https://assets.finn.no/pkg/@warp-ds/css/v1/components.css`,
   ];
@@ -101,14 +73,10 @@ const loadStyles = async (urls = []) => {
 };
 /**
  *
- * @param {import("./global.js").Brand} brand - target brand
  * @returns {Promise<StyleLoadResult>} CSS stylesheets as strings
  */
-export const getGlobalStyles = async (brand) => {
-  const { sld, tld } = brand;
+export const getGlobalStyles = async () => {
   const urls = [
-    `https://assets.finn.no/pkg/@warp-ds/fonts/v1/${sld}-${tld}.css`,
-    `https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/${sld}-${tld}.css`,
     `https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css`,
     `https://assets.finn.no/pkg/@warp-ds/css/v1/components.css`,
   ];


### PR DESCRIPTION
BREAKING CHANGE: fonts and tokens no longer provided. Both will need to be included in the document head via other means

This PR removes the token and font files from the base class since both of these penetrate the shadow dom. By doing this and ONLY including the token and font files 1x in the document head, updates will be significantly easier... update the page (likely through html-template) and you update all components on the page.

We should release this change under a "next" tag and do some further experimentation to see what issues arise from the change.