### PR TITLE
fix: support multiple entry points in the esbuild plugin

### DIFF
--- a/esbuild-plugin/package.json
+++ b/esbuild-plugin/package.json
@@ -24,6 +24,7 @@
     "@types/node": "20.11.27",
     "@warp-ds/elements-core": "0.0.1-alpha.12",
     "esbuild": "0.20.1",
+    "glob": "10.4.2",
     "lit": "2.7.6",
     "snapshot-assertion": "5.0.0",
     "tap": "18.7.1",

--- a/esbuild-plugin/snapshots/warp-3.snapshot
+++ b/esbuild-plugin/snapshots/warp-3.snapshot
@@ -1,0 +1,19 @@
+// test/fixtures/ssr/client/components/component.js
+import { LitElement, css, html } from "lit";
+var Component = class extends LitElement {
+  static styles = [
+    css`
+      *,:before,:after{--w-rotate:0;--w-rotate-x:0;--w-rotate-y:0;--w-rotate-z:0;--w-scale-x:1;--w-scale-y:1;--w-scale-z:1;--w-skew-x:0;--w-skew-y:0;--w-translate-x:0;--w-translate-y:0;--w-translate-z:0}.static{position:static}.text-xxl{font-size:var(--w-font-size-xxl);line-height:var(--w-line-height-xxl)};
+    `
+  ];
+  render() {
+    return html`
+            <section class"text-m">
+                <header class="text-xxl">Hello header</header>
+            </section>
+        `;
+  }
+};
+if (!customElements.get("my-component")) {
+  customElements.define("my-component", Component);
+}

--- a/esbuild-plugin/snapshots/warp-4.snapshot
+++ b/esbuild-plugin/snapshots/warp-4.snapshot
@@ -1,0 +1,33 @@
+import render from "./render.js";
+import { render as ssr } from "@lit-labs/ssr";
+import { html } from "lit";
+import "../client/components/component.js";
+function render() {
+  const results = [...ssr(html`<my-component></my-component>`)];
+  return results.join("");
+}
+export {
+  render as default
+};
+import "./components/component.js";
+import { LitElement, css, html } from "lit";
+class Component extends LitElement {
+  static styles = [
+    css`
+      *,:before,:after{--w-rotate:0;--w-rotate-x:0;--w-rotate-y:0;--w-rotate-z:0;--w-scale-x:1;--w-scale-y:1;--w-scale-z:1;--w-skew-x:0;--w-skew-y:0;--w-translate-x:0;--w-translate-y:0;--w-translate-z:0}.static{position:static}.text-xxl{font-size:var(--w-font-size-xxl);line-height:var(--w-line-height-xxl)};
+    `
+  ];
+  render() {
+    return html`
+            <section class"text-m">
+                <header class="text-xxl">Hello header</header>
+            </section>
+        `;
+  }
+}
+if (!customElements.get("my-component")) {
+  customElements.define("my-component", Component);
+}
+export {
+  Component as default
+};

--- a/esbuild-plugin/src/tree.js
+++ b/esbuild-plugin/src/tree.js
@@ -81,7 +81,9 @@ export class Tree {
       this._rootNode = node;
     } else {
       if (parent === undefined) {
-        throw new Error("Parent argument must be provided");
+        throw new Error(
+          `Parent argument must be provided when not a root node. This node ${path} has a root node ${this._rootNode}.`
+        );
       }
     }
 
@@ -97,10 +99,14 @@ export class Tree {
 
   tag(path, tag) {
     if (this._tags.has(tag)) {
-      throw new Error("Tag already exist");
+      throw new Error(`Tag ${tag} already exists`);
     }
 
     const node = this._registry.get(path);
+    if (!node) {
+      throw new Error(`No node at path ${path}`);
+    }
+
     node.setTag(tag);
     this._tags.set(tag, node);
   }
@@ -110,7 +116,9 @@ export class Tree {
     if (node) {
       node.setContent(content);
     } else {
-      throw new Error("Not able to set content. No existing node on path.");
+      throw new Error(
+        `Not able to set content. No existing node on path ${path}.`
+      );
     }
   }
 

--- a/esbuild-plugin/src/tree.js
+++ b/esbuild-plugin/src/tree.js
@@ -63,6 +63,14 @@ export class Tree {
 
   /**
    * @param {string} path
+   * @returns {boolean}
+   */
+  has(path) {
+    return this._registry.has(path);
+  }
+
+  /**
+   * @param {string} path
    * @param {string} [parent]
    * @returns {Node}
    */

--- a/esbuild-plugin/src/tree.js
+++ b/esbuild-plugin/src/tree.js
@@ -82,7 +82,7 @@ export class Tree {
     } else {
       if (parent === undefined) {
         throw new Error(
-          `Parent argument must be provided when not a root node. This node ${path} has a root node ${this._rootNode}.`
+          `Parent argument must be provided when not a root node. This node ${path} has a root node ${this._rootNode.getPath()}.`
         );
       }
     }

--- a/esbuild-plugin/test/fixtures/ssr/client/client.js
+++ b/esbuild-plugin/test/fixtures/ssr/client/client.js
@@ -1,0 +1,1 @@
+import "./components/component.js";

--- a/esbuild-plugin/test/fixtures/ssr/client/components/component.js
+++ b/esbuild-plugin/test/fixtures/ssr/client/components/component.js
@@ -1,0 +1,21 @@
+import { LitElement, css, html } from "lit";
+
+export default class Component extends LitElement {
+  static styles = [
+    css`
+      @warp-css;
+    `,
+  ];
+
+  render() {
+    return html`
+            <section class"text-m">
+                <header class="text-xxl">Hello header</header>
+            </section>
+        `;
+  }
+}
+
+if (!customElements.get("my-component")) {
+  customElements.define("my-component", Component);
+}

--- a/esbuild-plugin/test/fixtures/ssr/server/render.js
+++ b/esbuild-plugin/test/fixtures/ssr/server/render.js
@@ -1,0 +1,9 @@
+import { render as ssr } from "@lit-labs/ssr";
+import { html } from "lit";
+
+import "../client/components/component.js";
+
+export default function render() {
+  const results = [...ssr(html`<my-component></my-component>`)];
+  return results.join("");
+}

--- a/esbuild-plugin/test/fixtures/ssr/server/server.js
+++ b/esbuild-plugin/test/fixtures/ssr/server/server.js
@@ -1,0 +1,1 @@
+import render from "./render.js";

--- a/esbuild-plugin/test/tree.test.js
+++ b/esbuild-plugin/test/tree.test.js
@@ -218,7 +218,7 @@ test("Tree() - Set duplicate tag", () => {
 
   assert.throws(() => {
     tree.tag("/child.js", "tag");
-  }, /Tag already exist/);
+  }, /Tag tag already exists/);
 });
 
 test("Tree() - Walk the tree - Ignore tags", async () => {


### PR DESCRIPTION
This is often what we want for server-side rendering (build individual files rather than bundle). The current setup assumes only one entry-point/dependency tree.