### PR TITLE
chore: update plugin to Warp 2

### DIFF
--- a/esbuild-plugin/package.json
+++ b/esbuild-plugin/package.json
@@ -16,17 +16,17 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@unocss/core": "0.58.5",
-    "@warp-ds/css": "1.9.2",
-    "@warp-ds/uno": "1.10.2",
-    "browserslist": "4.23.0",
-    "lightningcss": "1.24.0",
-    "nanoid": "5.0.7"
+    "@unocss/core": "^0.58.5",
+    "@warp-ds/css": "^1.10.1",
+    "@warp-ds/uno": "^2.0.0",
+    "browserslist": "^4.23.0",
+    "lightningcss": "^1.24.0",
+    "nanoid": "^5.0.7"
   },
   "devDependencies": {
     "@types/node": "20.11.27",
-    "@warp-ds/elements-core": "0.0.1-alpha.12",
-    "esbuild": "0.20.1",
+    "@warp-ds/elements-core": "2.0.1",
+    "esbuild": "0.23.0",
     "glob": "10.4.2",
     "lit": "2.7.6",
     "snapshot-assertion": "5.0.0",


### PR DESCRIPTION
BREAKING CHANGE: now replaces warp-css with Warp 2 contents